### PR TITLE
store unformatted XMLs

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,7 @@ project('CXBTool', 'cpp',
 )
 
 lzo_dep = dependency('lzo2', fallback: ['lzo2', 'lzo2_dep'], static: true)
+pugixml_dep = dependency('pugixml', fallback: ['pugixml', 'pugixml_dep'], static: true)
 
 srcs = files(
   'src/main.cpp',
@@ -20,6 +21,7 @@ executable('CXBTool',
   include_directories: include_directories('.'),
   dependencies: [
     lzo_dep,
+    pugixml_dep,
   ],
   gui_app: false,
   link_args: [

--- a/src/cxb_parser.cpp
+++ b/src/cxb_parser.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <lzo/lzo2a.h>
 #include <cstdint>
+#include <pugixml.hpp>
 
 
 constexpr uint64_t MAGIC = 0x1004FA9957FBAA33;
@@ -179,10 +180,19 @@ std::vector<uint8_t> ConvertToCXB(const std::vector<CXBFile>& files) {
     }
 
     for (const auto& file : files) {
+        pugi::xml_document doc;
         std::string xmlStr = file.rawXml;
-        xmlStr.push_back('\0');
+        doc.load_string(xmlStr.c_str());
+        
+        // remove formatting
+        std::ostringstream oss;
+        doc.save(oss, "", pugi::format_raw);
+        
+        std::string minified = oss.str();
 
-        std::vector<uint8_t> xmlBytes(xmlStr.begin(), xmlStr.end());
+        minified.push_back('\0');
+
+        std::vector<uint8_t> xmlBytes(minified.begin(), minified.end());
         uint32_t uncompressedSize = xmlBytes.size();
 
         std::vector<uint8_t> blocks;

--- a/src/cxb_parser.hpp
+++ b/src/cxb_parser.hpp
@@ -3,6 +3,7 @@
 #include <map>
 #include <vector>
 #include <stdint.h>
+#include <pugixml.hpp>
 
 struct CXBFile {
     std::string name;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <set>
 #include <stdint.h>
+#include <pugixml.hpp>
 
 namespace fs = std::filesystem;
 
@@ -16,13 +17,20 @@ void exportCXB(const std::string& input, const std::string& outputDir) {
 
     fs::create_directories(outputDir);
     for (const auto& [filename, content] : xmls) {
+        pugi::xml_document doc;
+        pugi::xml_parse_result result = doc.load_string(content.c_str());
+        if (!result) {
+            std::cerr << "Failed to parse XML for " << filename
+                      << ": " << result.description() << "\n";
+            continue;
+        }
         std::string path = (fs::path(outputDir) / filename).string();
         std::ofstream out(path);
         if (!out) {
             std::cerr << "Failed to write " << path << "\n";
             continue;
         }
-        out << content;
+        doc.save(out, "    ", pugi::format_default | pugi::format_indent);
         std::cout << "Wrote " << path << "\n";
     }
 }

--- a/subprojects/pugixml.wrap
+++ b/subprojects/pugixml.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = pugixml-1.15
+source_url = https://github.com/zeux/pugixml/archive/v1.15.tar.gz
+source_filename = pugixml-1.15.tar.gz
+source_hash = b39647064d9e28297a34278bfb897092bf33b7c487906ddfc094c9e8868bddcb
+patch_filename = pugixml_1.15-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/pugixml_1.15-1/get_patch
+patch_hash = 71283431485c5e014c1e360033e84c56fda04171f9ba3bb48f37dd30c48e1d57
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/pugixml_1.15-1/pugixml-1.15.tar.gz
+wrapdb_version = 1.15-1
+
+[provide]
+pugixml = pugixml_dep


### PR DESCRIPTION
This strips indentation and newlines using [pugixml](https://github.com/zeux/pugixml) before compressing to save space. ACR specifically seems to have a file size limit and this saves a couple KB. ACB doesn't seem to have any issues with it.
Formatting is added back after decompression.

Fixes https://github.com/ACBMP/CXBTool/issues/3.